### PR TITLE
Make graphql a peer dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,4 @@
 # @elysiajs/graphql-yoga
 Plugin for [Elysia](https://github.com/elysiajs/elysia) for using graphql-yoga.
 
-## Install
-
-Install the plugin and `graphql` in the consuming app:
-
-```bash
-bun add @elysiajs/graphql-yoga graphql
-```
-
-```bash
-npm install @elysiajs/graphql-yoga graphql
-```
-
-The application should own the `graphql` runtime. This avoids duplicate `graphql`
-instances in real apps, which can otherwise lead to errors like
-`Cannot use GraphQLSchema "...\" from another module or realm.`
-
-Please refer to the [documentation](https://elysiajs.com/plugins/graphql-yoga.html)
-for usage details.
+Please refers to the [documentation](https://elysiajs.com/plugins/graphql-yoga.html) on how to use the package

--- a/README.md
+++ b/README.md
@@ -1,4 +1,21 @@
 # @elysiajs/graphql-yoga
 Plugin for [Elysia](https://github.com/elysiajs/elysia) for using graphql-yoga.
 
-Please refers to the [documentation](https://elysiajs.com/plugins/graphql-yoga.html) on how to use the package
+## Install
+
+Install the plugin and `graphql` in the consuming app:
+
+```bash
+bun add @elysiajs/graphql-yoga graphql
+```
+
+```bash
+npm install @elysiajs/graphql-yoga graphql
+```
+
+The application should own the `graphql` runtime. This avoids duplicate `graphql`
+instances in real apps, which can otherwise lead to errors like
+`Cannot use GraphQLSchema "...\" from another module or realm.`
+
+Please refer to the [documentation](https://elysiajs.com/plugins/graphql-yoga.html)
+for usage details.

--- a/bun.lock
+++ b/bun.lock
@@ -1,10 +1,10 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "@elysiajs/graphql-yoga",
       "dependencies": {
-        "graphql": "^16.6.0",
         "graphql-mobius": "^0.1.11",
         "graphql-yoga": "^3.9.1",
       },
@@ -15,11 +15,13 @@
         "@types/bun": "1.1.14",
         "elysia": "1.4.0",
         "eslint": "9.6.0",
+        "graphql": "^16.6.0",
         "tsup": "^8.1.0",
         "typescript": "^5.5.3",
       },
       "peerDependencies": {
-        "elysia": ">= 1.3.0",
+        "elysia": ">= 1.4.0",
+        "graphql": "^16.6.0",
       },
     },
   },

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
         "release": "npm run build && npm run test && npm publish --access public"
     },
     "dependencies": {
-        "graphql": "^16.6.0",
         "graphql-mobius": "^0.1.11",
         "graphql-yoga": "^3.9.1"
     },
@@ -48,18 +47,12 @@
         "@types/bun": "1.1.14",
         "elysia": "1.4.0",
         "eslint": "9.6.0",
+        "graphql": "^16.6.0",
         "tsup": "^8.1.0",
         "typescript": "^5.5.3"
     },
     "peerDependencies": {
-        "elysia": ">= 1.4.0"
-    },
-    "peerDependenciesMeta": {
-        "graphql": {
-            "optional": true
-        },
-        "graphql-yoga": {
-            "optional": true
-        }
+        "elysia": ">= 1.4.0",
+        "graphql": "^16.6.0"
     }
 }

--- a/test/node/cjs/package.json
+++ b/test/node/cjs/package.json
@@ -2,7 +2,6 @@
     "type": "commonjs",
     "dependencies": {
         "@elysiajs/graphql-yoga": "../../..",
-        "elysia": "^1.4.0",
         "graphql": "^16.13.1"
     }
 }

--- a/test/node/cjs/package.json
+++ b/test/node/cjs/package.json
@@ -1,6 +1,8 @@
 {
     "type": "commonjs",
     "dependencies": {
-        "@elysiajs/graphql-yoga": "../../.."
+        "@elysiajs/graphql-yoga": "../../..",
+        "elysia": "^1.4.0",
+        "graphql": "^16.13.1"
     }
 }

--- a/test/node/esm/package.json
+++ b/test/node/esm/package.json
@@ -2,7 +2,6 @@
     "type": "module",
     "dependencies": {
         "@elysiajs/graphql-yoga": "../../..",
-        "elysia": "^1.4.0",
         "graphql": "^16.13.1"
     }
 }

--- a/test/node/esm/package.json
+++ b/test/node/esm/package.json
@@ -1,6 +1,8 @@
 {
     "type": "module",
     "dependencies": {
-        "@elysiajs/graphql-yoga": "../../.."
+        "@elysiajs/graphql-yoga": "../../..",
+        "elysia": "^1.4.0",
+        "graphql": "^16.13.1"
     }
 }


### PR DESCRIPTION
## Summary
- make `graphql` a required peer dependency instead of a direct dependency
- keep `graphql` in dev dependencies so this repo still builds and tests locally
- update only the Node fixture manifests needed to install the peer during smoke tests

Closes #40

## Why
This package is a thin wrapper around `graphql-yoga`, but owning its own `graphql` dependency can cause consumers to end up with two GraphQL runtimes. That leads to schema/runtime mismatches such as:

```txt
Cannot use GraphQLSchema "..." from another module or realm.
```

Making `graphql` a peer lets the application own the runtime and avoids that duplication.

## Validation
- `bun install`
- `bun run build`
- `bun test`
- `npm run test:node`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated graphql dependency handling: graphql is now a required peer dependency that users must install separately (version ^16.6.0 or higher).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->